### PR TITLE
Fixed latency collector: it just werk!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 asprom
+debug
+debug.test

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Statistics collected:
 
   * aerospike_node_*: node wide statistics. e.g. memory usage, cluster state.
   * aerospike_ns_*: per namespace. e.g. objects, migrations.
-  * aerospike_latency_*: read/write/etc latency rates(!).
+  * aerospike_sets_*: statistics per set: objects, memory usage
+  * aerospike_latency_*: read/write/etc latency rates(!) (as asinfo -v "latency:" reports").
 
 TODOs:
 

--- a/latency.go
+++ b/latency.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -10,34 +11,25 @@ import (
 )
 
 var (
-	LatencyMetrics = []string{"reads", "writes_master", "proxy", "udf", "query"}
-	// should match the columns from `asinfo -v "latency:"`
-	LatencyIntervals = []string{">1ms", ">8ms", ">64ms"}
+	latencyMetrics = []string{"read", "write", "udf", "query"}
+	// should match operation types from `asinfo -v "latency:"`
+	latencyIntervals    = []string{">1ms", ">8ms", ">64ms"}
+	latencyOutputHeader = regexp.MustCompile("^{(?P<namespace>.+)}-(?P<operation>.+?):.+?,ops.sec,>1ms,>8ms,>64ms$")
 )
 
 type latencyCollector cmetrics
 
 func newLatencyCollector() latencyCollector {
 	lc := map[string]cmetric{}
-	for _, m := range LatencyMetrics {
-		lc[m+"_ops_sec"] = cmetric{
-			typ: prometheus.GaugeValue,
-			desc: prometheus.NewDesc(
-				promkey(systemLatency, m+"_ops_sec"),
-				m+" ops per second",
-				nil,
-				nil,
-			),
-		}
-		for _, int := range LatencyIntervals {
-			promName := strings.Replace(m+"_"+int, ">", "gt_", -1)
-			lc[m+"_"+int] = cmetric{
+	for _, m := range latencyMetrics {
+		for _, int := range latencyIntervals {
+			lc[m+int] = cmetric{
 				typ: prometheus.GaugeValue,
 				desc: prometheus.NewDesc(
-					promkey(systemLatency, promName),
-					m+" "+int,
-					nil,
-					nil,
+					promkey(systemLatency, m),
+					m+" latency histogram",
+					[]string{"namespace"},
+					prometheus.Labels{"gt": int[1:]},
 				),
 			}
 		}
@@ -58,51 +50,52 @@ func (lc latencyCollector) collect(conn *as.Connection, ch chan<- prometheus.Met
 		return
 	}
 	lat := parseLatency(stats["latency:"])
-	for typ, ls := range lat {
-		for k, v := range ls {
-			switch {
-			case k == "ops/sec":
-				if m, ok := lc[typ+"_ops_sec"]; ok {
-					ch <- prometheus.MustNewConstMetric(m.desc, m.typ, v)
-				} else {
-					log.Printf("unknown latency type: %q", typ)
-				}
-			case strings.HasPrefix(k, ">"):
-				if m, ok := lc[typ+"_"+k]; ok {
-					ch <- prometheus.MustNewConstMetric(m.desc, m.typ, v)
-				}
+	for namespace, metrics := range lat {
+		for metric, data := range metrics {
+			if m, ok := lc[metric]; ok {
+				ch <- prometheus.MustNewConstMetric(m.desc, m.typ, data, namespace)
 			}
 		}
 	}
 }
 
 func parseLatency(lat string) map[string]map[string]float64 {
-	resAll := map[string]map[string]float64{}
+	var namespace, operation string
+	results := map[string]map[string]float64{}
 	// Lines come in pairs, and look like this:
-	// reads:19:21:58-GMT,ops/sec,>1ms,>8ms,>64ms;19:22:08,12469.3,0.40,0.00,0.00;writes_master:19:21:58-GMT,ops/sec,>1ms,>8ms,>64ms;19:22:08,0.0,0.00,0.00,0.00;proxy:19:21:58-GMT,ops/sec,>1ms,>8ms,>64ms;19:22:08,0.0,0.00,0.00,0.00;udf:19:21:58-GMT,ops/sec,>1ms,>8ms,>64ms;19:22:08,14730.7,0.03,0.00,0.00;query:19:21:58-GMT,ops/sec,>1ms,>8ms,>64ms;19:22:08,0.0,0.00,0.00,0.00;
+	// reads:{namespace}-read:14:08:38-GMT,ops/sec,>1ms,>8ms,>64ms;14:08:48,2586.8,1.58,0.77,0.00;
 	lines := strings.Split(lat, ";")
-	for len(lines) >= 2 {
-		first := strings.SplitN(lines[0], ":", 2)
-		if len(first) != 2 {
-			log.Print("invalid latency format")
-			return nil
-		}
-		typ := first[0]
-		headers := strings.Split(first[1], ",")
-		values := strings.Split(lines[1], ",")
-		lines = lines[2:]
-
-		res := map[string]float64{}
-		for i, h := range headers[1:] {
-			v := values[i+1]
-			f, err := strconv.ParseFloat(v, 64)
-			if err != nil {
-				log.Printf("%q invalid latency value %q: %s", h, v, err)
-				continue
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "error") {
+			match := latencyOutputHeader.FindStringSubmatch(line)
+			if len(match) > 0 {
+				namespace = match[1]
+				operation = match[2]
+			} else {
+				values := strings.Split(line, ",")
+				if len(values) != 5 {
+					log.Print("invalid latency format")
+					return nil
+				}
+				result, ok := results[namespace]
+				if !ok {
+					result = map[string]float64{}
+				}
+				for i, v := range values[2:] {
+					f, err := strconv.ParseFloat(v, 64)
+					if err != nil {
+						log.Printf("%q invalid latency value %q: %s", namespace, v, err)
+						continue
+					}
+					result[operation+latencyIntervals[i]] = f
+				}
+				for _, item := range latencyMetrics {
+					if operation == item {
+						results[namespace] = result
+					}
+				}
 			}
-			res[h] = f
 		}
-		resAll[typ] = res
 	}
-	return resAll
+	return results
 }

--- a/latency_test.go
+++ b/latency_test.go
@@ -6,37 +6,20 @@ import (
 )
 
 func TestParseLatency(t *testing.T) {
-	lat := "reads:19:21:58-GMT,ops/sec,>1ms,>8ms,>64ms;19:22:08,12469.3,0.40,0.00,0.00;writes_master:19:21:58-GMT,ops/sec,>1ms,>8ms,>64ms;19:22:08,0.0,0.00,0.00,0.00;proxy:19:21:58-GMT,ops/sec,>1ms,>8ms,>64ms;19:22:08,0.0,0.00,0.00,0.00;udf:19:21:58-GMT,ops/sec,>1ms,>8ms,>64ms;19:22:08,14730.7,0.03,0.00,0.00;query:19:21:58-GMT,ops/sec,>1ms,>8ms,>64ms;19:22:08,1.2,3.45,5.67,7.89;"
+	lat := "error-no-data-yet-or-back-too-small;error-no-data-yet-or-back-too-small;{sys}-read:15:26:23-GMT,ops/sec,>1ms,>8ms,>64ms;15:26:33,54.4,1.10,0.55,0.00;{test}-write:15:26:23-GMT,ops/sec,>1ms,>8ms,>64ms;15:26:33,4.0,0.00,0.00,0.00;error-no-data-yet-or-back-too-small;{sys}-query:15:26:23-GMT,ops/sec,>1ms,>8ms,>64ms;15:26:33,0.2,100.00,0.00,0.00"
 	want := map[string]map[string]float64{
-		"reads": {
-			"ops/sec": 12469.3,
-			">1ms":    0.4,
-			">8ms":    0.0,
-			">64ms":   0.0,
+		"sys": {
+			"read>1ms":   1.10,
+			"read>8ms":   0.55,
+			"read>64ms":  0.0,
+			"query>1ms":  100.00,
+			"query>8ms":  0.0,
+			"query>64ms": 0.0,
 		},
-		"writes_master": {
-			"ops/sec": 0.0,
-			">1ms":    0.0,
-			">8ms":    0.0,
-			">64ms":   0.0,
-		},
-		"proxy": {
-			"ops/sec": 0.0,
-			">1ms":    0.0,
-			">8ms":    0.0,
-			">64ms":   0.0,
-		},
-		"udf": {
-			"ops/sec": 14730.7,
-			">1ms":    0.03,
-			">8ms":    0.0,
-			">64ms":   0.0,
-		},
-		"query": {
-			"ops/sec": 1.2,
-			">1ms":    3.45,
-			">8ms":    5.67,
-			">64ms":   7.89,
+		"test": {
+			"write>1ms":  0.0,
+			"write>8ms":  0.0,
+			"write>64ms": 0.0,
 		},
 	}
 	if have := parseLatency(lat); !reflect.DeepEqual(have, want) {


### PR DESCRIPTION
Hi, it's me again.
I study Go and use your as collector – so I decided to improve it again a little. Namely latency collection.
It couldn't parse asinfo output since aerospike developers have changed it format, so I fix it.

I've changed a bit format of exported metrics: it doesn't export ops/sec metrics from 'asinfo -v "latency:"', because it doesn't apply to latency at all. "gt>...ms" values exported as labels, like this:

```
aerospike_latency_write{gt="64ms",namespace="pool"} 0
aerospike_latency_write{gt="8ms",namespace="name"} 0
aerospike_latency_write{gt="64ms",namespace="rmq_msg"} 0
aerospike_latency_write{gt="1ms",namespace="sys"} 0
```
Also updated Readme.