### PR TITLE
add compression ratio and quiesce stats

### DIFF
--- a/namespaces.go
+++ b/namespaces.go
@@ -195,7 +195,7 @@ var (
 		// geo2dsphere-within.max-cells=12
 		// geo2dsphere-within.level-mod=1
 		// geo2dsphere-within.earth-radius-meters=6371000
-    gauge("device_compression_ratio", "device compression ratio"),
+		gauge("device_compression_ratio", "device compression ratio"),
 	}
 )
 

--- a/namespaces.go
+++ b/namespaces.go
@@ -196,6 +196,9 @@ var (
 		// geo2dsphere-within.level-mod=1
 		// geo2dsphere-within.earth-radius-meters=6371000
 		gauge("device_compression_ratio", "device compression ratio"),
+		gauge("n_nodes_quiesced", "n nodes quiesced"),
+		gauge("effective_is_quiesced", "effective is quiesced"),
+		gauge("pending_quiesce", "pending quiesce"),
 	}
 )
 

--- a/namespaces.go
+++ b/namespaces.go
@@ -195,6 +195,7 @@ var (
 		// geo2dsphere-within.max-cells=12
 		// geo2dsphere-within.level-mod=1
 		// geo2dsphere-within.earth-radius-meters=6371000
+    gauge("device_compression_ratio", "device compression ratio"),
 	}
 )
 


### PR DESCRIPTION
```# curl localhost:9145/metrics 2>/dev/null|grep compression_ratio
# HELP aerospike_ns_device_compression_ratio device compression ratio
# TYPE aerospike_ns_device_compression_ratio gauge
aerospike_ns_device_compression_ratio{namespace="baz"} 0.746


https://www.aerospike.com/docs/operations/configure/namespace/storage/compression.html