### PR TITLE
EE] Add metrics for primary index on flash

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -97,6 +97,7 @@ func counter(name string, desc string) metric {
 
 // promkey makes the prom metric name out of an aerospike stat name
 func promkey(sys, key string) string {
-	k := strings.Replace(key, "-", "_", -1)
+	replacer := strings.NewReplacer("-", "_", ".", "_")
+	k := replacer.Replace(key)
 	return namespace + "_" + sys + "_" + k
 }

--- a/namespaces.go
+++ b/namespaces.go
@@ -199,6 +199,10 @@ var (
 		gauge("n_nodes_quiesced", "n nodes quiesced"),
 		gauge("effective_is_quiesced", "effective is quiesced"),
 		gauge("pending_quiesce", "pending quiesce"),
+		gauge("index-type.mounts-high-water-pct", "index type mounts high water pct"),
+		gauge("index-type.mounts-size-limit", "index type mounts size limit"),
+		gauge("index_flash_used_bytes", "index flash used bytes"),
+		gauge("index_flash_used_pct", "index flash used pct"),
 	}
 )
 


### PR DESCRIPTION
```
Admin> show statistics like index-type
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~test Namespace Statistics (2019-03-13 19:26:18 UTC)~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
NODE                            :   astest01ea1:3000           astest02ea1:3000           astest03ea1:3000        
index-type                      :   flash                      flash                      flash
index-type.mount[0]             :   /test_primary_index        /test_primary_index        /test_primary_index
index-type.mount[0].age         :   0                          0                          0
index-type.mounts-high-water-pct:   80                         80                         80
index-type.mounts-size-limit    :   1099511627776              1099511627776              1099511627776

Admin> show statistics like flash
~~~~~~~~~~~~~~~~~~~~~~~~~~test Namespace Statistics (2019-03-13 19:26:25 UTC)~~~~~~~~~~~~~~~~~~~~~~~~~~~
NODE                  :   astest01ea1:3000           astest02ea1:3000           astest03ea1:3000        
index_flash_used_bytes:   0                          0                          0
index_flash_used_pct  :   0                          0                          0
```

```
curl -s localhost:10000/metrics | grep 'index_type\|index_flash'
# HELP aerospike_ns_index_flash_used_bytes index flash used bytes
# TYPE aerospike_ns_index_flash_used_bytes gauge
aerospike_ns_index_flash_used_bytes{namespace="test"} 0
# HELP aerospike_ns_index_flash_used_pct index flash used pct
# TYPE aerospike_ns_index_flash_used_pct gauge
aerospike_ns_index_flash_used_pct{namespace="test"} 0
# HELP aerospike_ns_index_type_mounts_high_water_pct index type mounts high water pct
# TYPE aerospike_ns_index_type_mounts_high_water_pct gauge
aerospike_ns_index_type_mounts_high_water_pct{namespace="test"} 80
# HELP aerospike_ns_index_type_mounts_size_limit index type mounts size limit
# TYPE aerospike_ns_index_type_mounts_size_limit gauge
aerospike_ns_index_type_mounts_size_limit{namespace="test"} 1.099511627776e+12
```