### PR TITLE
Histogram style latency

### DIFF
--- a/latency.go
+++ b/latency.go
@@ -16,22 +16,48 @@ var (
 )
 
 type latencyCollector struct {
-	latency cmetrics
-	ops     cmetrics
+	latency          cmetrics
+	latencyHistogram cmetrics
+	ops              cmetrics
+	histOps          cmetrics
+	bucketSum        cmetrics
 }
 
 func newLatencyCollector() latencyCollector {
 	lc := latencyCollector{
-		latency: map[string]cmetric{},
-		ops:     map[string]cmetric{},
+		latency:          map[string]cmetric{},
+		latencyHistogram: map[string]cmetric{},
+		ops:              map[string]cmetric{},
+		histOps:          map[string]cmetric{},
+		bucketSum:        map[string]cmetric{},
 	}
 	for _, m := range latencyMetrics {
 		lc.latency[m] = cmetric{
 			typ: prometheus.GaugeValue,
 			desc: prometheus.NewDesc(
 				promkey(systemLatency, m),
+				m+" latency",
+				[]string{"namespace", "threshold"}, // threshold to be printed as le for histogram
+				nil,
+			),
+		}
+		lc.latencyHistogram[m] = cmetric{
+			typ: prometheus.GaugeValue,
+			desc: prometheus.NewDesc(
+				// for prom histogram latency buckets, metric must end in _bucket
+				promkey(systemLatencyHist, m+"_bucket"),
 				m+" latency histogram",
-				[]string{"namespace", "threshold"},
+				[]string{"namespace", "le"}, // threshold to be printed as le for histogram, le="1" means ops that completed in less than 1ms
+				nil,
+			),
+		}
+		lc.histOps[m] = cmetric{
+			typ: prometheus.GaugeValue,
+			desc: prometheus.NewDesc(
+				// for prom histogram, must have a metric ending in _count which is equal to the sum of all observed events
+				promkey(systemLatencyHist, m+"_count"),
+				m+" ops per second for histogram",
+				[]string{"namespace"},
 				nil,
 			),
 		}
@@ -40,6 +66,16 @@ func newLatencyCollector() latencyCollector {
 			desc: prometheus.NewDesc(
 				promkey(systemOps, m),
 				m+" ops per second",
+				[]string{"namespace"},
+				nil,
+			),
+		}
+		lc.bucketSum[m] = cmetric{
+			typ: prometheus.GaugeValue,
+			desc: prometheus.NewDesc(
+				// for prom histogram, must have a metric ending in _sum which is equal to the sum of all observed events values
+				promkey(systemLatencyHist, m+"_sum"),
+				m+" sum of all buckets",
 				[]string{"namespace"},
 				nil,
 			),
@@ -55,6 +91,15 @@ func (lc latencyCollector) describe(ch chan<- *prometheus.Desc) {
 	for _, s := range lc.ops {
 		ch <- s.desc
 	}
+	for _, s := range lc.histOps {
+		ch <- s.desc
+	}
+	for _, s := range lc.bucketSum {
+		ch <- s.desc
+	}
+	for _, s := range lc.latencyHistogram {
+		ch <- s.desc
+	}
 }
 
 func (lc latencyCollector) collect(conn *as.Connection) ([]prometheus.Metric, error) {
@@ -67,6 +112,8 @@ func (lc latencyCollector) collect(conn *as.Connection) ([]prometheus.Metric, er
 		return nil, err
 	}
 	var metrics []prometheus.Metric
+	re := regexp.MustCompile("[0-9.]+") // regex to pull the number from the bucket name, >1ms -> 1, >8ms -> 8 etc.
+
 	for key, ms := range lat {
 		if key == "batch-index" {
 			continue // TODO: would be nice to do something with this key
@@ -75,21 +122,61 @@ func (lc latencyCollector) collect(conn *as.Connection) ([]prometheus.Metric, er
 		if err != nil {
 			return nil, fmt.Errorf("weird latency key %q: %s", key, err)
 		}
+		// need to grab ops outside of the latency loop
+		// so that we can use it for estimatedBucketOps later
+		// the latency map could be out of order, so OPS/S needs to be accessed first
+		ops := ms["ops/sec"]
+		var bucketSum float64
+		histOpsMetric := lc.histOps[op]
+		metrics = append(
+			metrics,
+			prometheus.MustNewConstMetric(histOpsMetric.desc, histOpsMetric.typ, ops, ns),
+		)
+
+		opsMetric := lc.ops[op]
+		metrics = append(
+			metrics,
+			prometheus.MustNewConstMetric(opsMetric.desc, opsMetric.typ, ops, ns),
+		)
+
 		for threshold, data := range ms {
 			if threshold == "ops/sec" {
-				m := lc.ops[op]
-				metrics = append(
-					metrics,
-					prometheus.MustNewConstMetric(m.desc, m.typ, data, ns),
-				)
 				continue
 			}
-			m := lc.latency[op]
+			thresholdNum := re.FindString(threshold) // filter out >1ms to just the number 1, similarly >8ms becomes 8..
+			bucketVal, _ := strconv.ParseFloat(thresholdNum, 64)
+			m := lc.latencyHistogram[op]
+			// latency is exported as % in certain buckets.
+			// For histogram consumption, it would be nice to have the estimated number of
+			// operations in each bucket instead. So this is just some simple math to figure out, given the total ops/s and % in each bucket
+			// How many ops in each bucket.
+			estimatedBucketOps := ops * data / 100.0
+			bucketSum += (bucketVal * estimatedBucketOps) // to generate sum like aerospike_latency_hist_read_sum
+			if bucketVal == 1.0 {
+				below1msAssumption := ops - estimatedBucketOps
+				bucketSum += 0.5 * below1msAssumption // for the blahblah_sum histogram metric, to calculate averages, assume the transactions <1ms are .5ms
+			}
+			leBucketOps := ops - estimatedBucketOps
+			metrics = append(
+				metrics,
+				prometheus.MustNewConstMetric(m.desc, m.typ, leBucketOps, ns, thresholdNum),
+			)
+			m = lc.latency[op]
 			metrics = append(
 				metrics,
 				prometheus.MustNewConstMetric(m.desc, m.typ, data, ns, threshold),
 			)
 		}
+		m := lc.bucketSum[op]
+		metrics = append(
+			metrics,
+			prometheus.MustNewConstMetric(m.desc, m.typ, bucketSum, ns),
+		)
+		m = lc.latencyHistogram[op]
+		metrics = append(
+			metrics,
+			prometheus.MustNewConstMetric(m.desc, m.typ, ops, ns, "+Inf"),
+		)
 	}
 	return metrics, nil
 }
@@ -109,7 +196,6 @@ func parseLatency(lat string) (map[string]map[string]float64, error) {
 		vs := strings.Split(line, ",")
 		key := strings.SplitN(vs[0], ":", 2)[0] // strips timestamp
 		cols := vs[1:]
-
 		if i+1 >= len(lines) {
 			return nil, fmt.Errorf("latency: missing measurements line")
 		}

--- a/main.go
+++ b/main.go
@@ -26,12 +26,13 @@ import (
 )
 
 const (
-	namespace       = "aerospike"
-	systemNode      = "node"
-	systemNamespace = "ns"
-	systemLatency   = "latency"
-	systemOps       = "ops" // reported in latency
-	systemSet       = "set"
+	namespace         = "aerospike"
+	systemNode        = "node"
+	systemNamespace   = "ns"
+	systemLatency     = "latency"
+	systemLatencyHist = "latency_hist" // total number of ops
+	systemOps         = "ops"
+	systemSet         = "set"
 )
 
 var (


### PR DESCRIPTION
The goal is to be able to put this data into a heatmap, to be able to calculate a quantile latency metric using prometheus functions, calculate average latency, and to be able to find the number of ops in certain buckets easily.

The server only returns the ops/s and the %'s in each bucket, so extrapolating the number of ops back into each bucket and converting it to a prometheus style histogram. 

I haven't written anything in golang before, so please forgive me if this looks horrible.

- This allows use of prom/grafana heatmaps, and histogram_quantile functions.
- Average latency can be calculated by `aerospike_latency_hist_write_sum/aerospike_latency_hist_write_count`
- You can for example fetch the 95th percentile using histogram_quantile like so: `histogram_quantile(0.95,sum(aerospike_latency_read_bucket) by (le))` you can also find the estimated number of ops that exceeded a certain bucket value, rather than just the %.
- I originally removed the latency metrics, but decided it would be bad to make this a breaking change for everyone. So if something looks to be missing or off that might be the cause, or just my horrible golang skills.

```
# HELP aerospike_latency_hist_read_bucket read latency histogram
# TYPE aerospike_latency_hist_read_bucket gauge
aerospike_latency_hist_read_bucket{le="+Inf",namespace="test"} 5832.4
aerospike_latency_hist_read_bucket{le="1",namespace="test"} 5830.06704
aerospike_latency_hist_read_bucket{le="64",namespace="test"} 5832.4
aerospike_latency_hist_read_bucket{le="8",namespace="test"} 5831.81676
# HELP aerospike_latency_hist_read_count read ops per second for histogram
# TYPE aerospike_latency_hist_read_count gauge
aerospike_latency_hist_read_count{namespace="test"} 5832.4
# HELP aerospike_latency_hist_read_sum read sum of all buckets
# TYPE aerospike_latency_hist_read_sum gauge
aerospike_latency_hist_read_sum{namespace="test"} 2922.0324
# HELP aerospike_latency_hist_write_bucket write latency histogram
# TYPE aerospike_latency_hist_write_bucket gauge
aerospike_latency_hist_write_bucket{le="+Inf",namespace="test"} 5782.6
aerospike_latency_hist_write_bucket{le="1",namespace="test"} 5779.7087
aerospike_latency_hist_write_bucket{le="64",namespace="test"} 5782.02174
aerospike_latency_hist_write_bucket{le="8",namespace="test"} 5782.02174
# HELP aerospike_latency_hist_write_count write ops per second for histogram
# TYPE aerospike_latency_hist_write_count gauge
aerospike_latency_hist_write_count{namespace="test"} 5782.6
# HELP aerospike_latency_hist_write_sum write sum of all buckets
# TYPE aerospike_latency_hist_write_sum gauge
aerospike_latency_hist_write_sum{namespace="test"} 2934.38037
# HELP aerospike_latency_read read latency
# TYPE aerospike_latency_read gauge
aerospike_latency_read{namespace="test",threshold=">1ms"} 0.04
aerospike_latency_read{namespace="test",threshold=">64ms"} 0
aerospike_latency_read{namespace="test",threshold=">8ms"} 0.01
# HELP aerospike_latency_write write latency
# TYPE aerospike_latency_write gauge
aerospike_latency_write{namespace="test",threshold=">1ms"} 0.05
aerospike_latency_write{namespace="test",threshold=">64ms"} 0.01
aerospike_latency_write{namespace="test",threshold=">8ms"} 0.01
```

Note: for average latency purposes, this assumes the transactions <1ms are .5ms