### PR TITLE
secondary indexes] Scrape metrics specific to secondary indexes.

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ const (
 	systemLatencyHist = "latency_hist" // total number of ops
 	systemOps         = "ops"
 	systemSet         = "set"
+	secondaryIndex    = "sindex"
 )
 
 var (
@@ -129,6 +130,7 @@ func newAsCollector(nodeAddr, username, password string) *asCollector {
 			newNSCollector(),
 			newLatencyCollector(),
 			newSetCollector(),
+			newSindexCollector(),
 		},
 	}
 }

--- a/sindex.go
+++ b/sindex.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+  "strings"
+
+  as "github.com/aerospike/aerospike-client-go"
+  "github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+  // SindexMetrics lists the keys we report from aero's sindex statistics command.
+  // See `asinfo -l -v sindex` for a list of secondary indexes.
+  // See `asinfo -l -v sindex/<namespace>` for a list of secondary indexes for a given namespace.
+  // See `asinfo -l -v sindex/<namespace>/<sindex_name>` for detailed metrics for a given secondary index.
+  SindexMetrics = []metric{
+    gauge("keys", "keys"),
+    gauge("entries", "entries"),
+    gauge("ibtr_memory_used", "ibtr_memory_used"),
+    gauge("nbtr_memory_used", "nbtr_memory_used"),
+    gauge("si_accounted_memory", "si_accounted_memory"),
+    gauge("load_pct", "load_pct"),
+    counter("loadtime", "loadtime"),
+    counter("write_success", "write_success"),
+    counter("write_error", "write_error"),
+    counter("delete_success", "delete_success"),
+    counter("delete_error", "delete_error"),
+    counter("stat_gc_recs", "stat_gc_recs"),
+    counter("stat_gc_time", "stat_gc_time"),
+    counter("query_reqs", "query_reqs"),
+    gauge("query_avg_rec_count", "query_avg_rec_count"),
+    gauge("query_avg_record_size", "query_avg_record_size"),
+    counter("query_agg", "query_agg"),
+    gauge("query_agg_avg_rec_count", "query_agg_avg_rec_count"),
+    gauge("query_agg_avg_record_size", "query_agg_avg_record_size"),
+    counter("query_lookups", "query_lookups"),
+    gauge("query_lookup_avg_rec_count", "query_lookup_avg_rec_count"),
+    gauge("query_lookup_avg_record_size", "query_lookup_avg_record_size"),
+  }
+)
+
+type sindexCollector cmetrics
+
+func newSindexCollector() sindexCollector {
+  sindex := map[string]cmetric {}
+  for _, m := range SindexMetrics {
+    sindex[m.aeroName] = cmetric{
+      typ: m.typ,
+      desc: prometheus.NewDesc(
+        promkey(secondaryIndex, m.aeroName),
+        m.desc,
+        []string{"namespace", "sindex", "set", "bin", "type", "indextype", "path"},
+        nil,
+      ),
+    }
+  }
+  return sindex
+}
+
+func (sindexc sindexCollector) describe(ch chan<- *prometheus.Desc) {
+  for _, s := range sindexc {
+    ch <- s.desc
+  }
+}
+
+func (sic sindexCollector) collect(conn *as.Connection) ([]prometheus.Metric, error) {
+  info, err := as.RequestInfo(conn, "sindex")
+  if err != nil {
+    return nil, err
+  }
+
+  var metrics []prometheus.Metric
+  for _, sindexInfo := range strings.Split(info["sindex"], ";") {
+    if sindexInfo == "" {
+      continue
+    }
+    sindexStats := parseInfo(sindexInfo)
+    ns := sindexStats["ns"]
+    sindexName := sindexStats["indexname"]
+    sindexDetails, err := as.RequestInfo(conn, "sindex/"+ns+"/"+sindexName)
+    if err != nil {
+      return nil, err
+    }
+
+    metrics = append(
+      metrics,
+      infoCollect(
+        cmetrics(sic),
+        sindexDetails["sindex/"+ns+"/"+sindexName],
+        ns,
+        sindexName,
+        sindexStats["set"],
+        sindexStats["bin"],
+        sindexStats["type"],
+        sindexStats["indextype"],
+        sindexStats["path"],
+      )...,
+    )
+  }
+  return metrics, nil
+}


### PR DESCRIPTION
Adding all the metrics I could find for secondary indexes.
Some of the counter vs. gauge are really guesses from me at this point... But I think they're sane.

One of the info we get from `asinfo -l -v sindex` is `state` which is either equal to `WO` (index being built) or `RW` (can run querries against it).  
I didn't feel like this was a valid tag/label. So it's not included. It might have been useful as yet another gauge (maybe `aerospike_sindex_is_rw`) but I wasn't sure what the best way to implement that would have been. I'm also expecting that `aerospike_sindex_load_pct` technically achieves the same thing. I assume that when that value reaches 100, the state switches to `RW`.

```
❯ curl -s localhost:9146/metrics | grep <set>_partition_idx
aerospike_sindex_delete_error{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_delete_success{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_entries{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 245230
aerospike_sindex_ibtr_memory_used{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 58880
aerospike_sindex_keys{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 1024
aerospike_sindex_load_pct{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 100
aerospike_sindex_loadtime{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 372623
aerospike_sindex_nbtr_memory_used{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 8.64448e+06
aerospike_sindex_query_agg{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_query_agg_avg_rec_count{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_query_agg_avg_record_size{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_query_avg_rec_count{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_query_avg_record_size{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_query_lookup_avg_rec_count{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_query_lookup_avg_record_size{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_query_lookups{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_query_reqs{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_si_accounted_memory{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 8.70336e+06
aerospike_sindex_stat_gc_recs{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_stat_gc_time{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_write_error{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 0
aerospike_sindex_write_success{bin="partition",indextype="NONE",namespace="<namespace>",path="partition",set="<set>",sindex="<set>_partition_idx",type="NUMERIC"} 245230
```

[EDIT]
For reference:
```
❯ asinfo -l -v sindex | grep <set>_partition_idx | sed 's/:/\n/g'
ns=<namespace>
set=<set>
indexname=<set>_partition_idx
bin=partition
type=NUMERIC
indextype=NONE
path=partition
state=RW

❯ asinfo -l -v sindex/<namespace>/<set>_partition_idx
keys=1024
entries=245230
ibtr_memory_used=58880
nbtr_memory_used=8644480
si_accounted_memory=8703360
load_pct=100
loadtime=372623
write_success=245230
write_error=0
delete_success=0
delete_error=0
stat_gc_recs=0
stat_gc_time=0
query_reqs=0
query_avg_rec_count=0
query_avg_record_size=0
query_agg=0
query_agg_avg_rec_count=0
query_agg_avg_record_size=0
query_lookups=0
query_lookup_avg_rec_count=0
query_lookup_avg_record_size=0
histogram=false
```