### PR TITLE
Adding truncate / truncate_lut metrics for namespaces and sets

### DIFF
--- a/namespaces.go
+++ b/namespaces.go
@@ -55,8 +55,6 @@ var (
 		// storage-engine=memory
 		// tomb-raider-eligible-age=86400
 		// tomb-raider-period=86400
-		// truncate_lut=0
-		// truncated_records=0
 		// write-commit-level-override=off
 		// xmem_id=0
 		counter("batch_sub_proxy_complete", "batch sub proxy complete"),
@@ -152,6 +150,7 @@ var (
 		counter("scan_udf_bg_abort", "scan udf bg abort"),
 		counter("scan_udf_bg_complete", "scan udf bg complete"),
 		counter("scan_udf_bg_error", "scan udf bg error"),
+		counter("truncated_records", "truncated records"),
 		counter("udf_sub_lang_delete_success", "udf sub lang delete success"),
 		counter("udf_sub_lang_error", "udf sub lang error"),
 		counter("udf_sub_lang_read_success", "udf sub lang read success"),
@@ -217,6 +216,7 @@ var (
 		gauge("stop_writes", "stop writes"),
 		gauge("stop-writes-pct", "stop writes pct"),
 		gauge("tombstones", "tombstones"),
+		gauge("truncate_lut", "The most covering truncate_lut for this namespace"),
 		// including additional key metrics as recommended by aerospike  https://www.aerospike.com/docs/operations/monitor/key_metrics/index.html
 		gauge("clock_skew_stop_writes", "clock skew stop writes"),
 		gauge("dead_partitions", "dead partitions"),

--- a/sets.go
+++ b/sets.go
@@ -12,8 +12,9 @@ var (
 	// command.
 	// See `asinfo -l -v sets` for the full list.
 	SetMetrics = []metric{
-		gauge("objects", "objects"),
 		gauge("memory_data_bytes", "memory data bytes"),
+		gauge("objects", "objects"),
+		gauge("truncate_lut", "The most covering truncate_lut for this set"),
 		counter("stop-writes-count", "stop writes count"),
 	}
 )


### PR DESCRIPTION
```
❯ curl -s localhost:9146/metrics | grep truncate | grep -v ' 0$'
# HELP aerospike_ns_truncate_lut The most covering truncate_lut for this namespace
# TYPE aerospike_ns_truncate_lut gauge
# HELP aerospike_ns_truncated_records truncated records
# TYPE aerospike_ns_truncated_records counter
aerospike_ns_truncated_records{namespace="<namespace>"} 1.00091747e+08
# HELP aerospike_set_truncate_lut The most covering truncate_lut for this set
# TYPE aerospike_set_truncate_lut gauge
aerospike_set_truncate_lut{namespace="<namespace>",set="<set1>"} 3.25275438944e+11
aerospike_set_truncate_lut{namespace="<namespace>",set="<set2>"} 3.26384163993e+11
```