### PR TITLE
sanitize label values for invalid utf-8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/prometheus/procfs v0.0.0-20190519111021-9935e8e0588d // indirect
 	github.com/yuin/gopher-lua v0.0.0-20181214045814-db9ae37725ec // indirect
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
+	golang.org/x/text v0.3.0
 )


### PR DESCRIPTION
Hi, 

we encountered a problem with the exporter and utf-8 labels. When label value is not a valid utf-8 the prometheus client rejects it and exporter panics. We had invalid utf-8 value in the set name. This is certainly not a common issue but I think it is better to handle it if Aerospike server accepts it. 

I will add this change also to this project https://github.com/aerospike/aerospike-prometheus-exporter/blob/master/watcher_sets.go after it will be merged here.

