### PR TITLE
Make non-utf8 labels unique

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"fmt"
 	"log"
 	"strconv"
@@ -80,7 +81,7 @@ func sanitizeLabelValue(lv string) string {
 		return r
 	}
 
-	return strings.Map(fixUtf, lv)
+	return strings.Map(fixUtf, lv) + " " + hex.EncodeToString([]byte(lv))
 }
 
 func parseInfo(s string) map[string]string {

--- a/metric_test.go
+++ b/metric_test.go
@@ -118,7 +118,7 @@ func TestInfoCollect(t *testing.T) {
 			},
 			//labels: []string{"ns", ""},
 			labels: []string{"ns", "\xC0"},
-			want: `label:<name:"namespace" value:"ns" > label:<name:"set" value:"\357\277\275" > gauge:<value:1 > `,
+			want: `label:<name:"namespace" value:"ns" > label:<name:"set" value:"\357\277\275 c0" > gauge:<value:1 > `,
 		},
 		{
 			payload: "counter-1=3.14:gauge-1=6.12:flag=true:counter-2=6.66",


### PR DESCRIPTION
Normalized non-utf-8 labels may not be unique - I added hex of the original data to make it unique and consistent.